### PR TITLE
Fix wrong overload of queryMetadataAll being called

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -808,7 +808,7 @@ constructor(
 
                 else -> {
                     if (before == null) {
-                            articleDao.queryMetadataAll(accountId, !isUnread)
+                            articleDao.queryMetadataAll(accountId, isUnread = !isUnread)
                         } else {
                             articleDao.queryMetadataAll(accountId, !isUnread, before)
                         }


### PR DESCRIPTION
## Problem

`queryMetadataAll` has these two overloads:

```kotlin
fun queryMetadataAll(
    accountId: Int, sortAscending: Boolean = false
): List

fun queryMetadataAll(
    accountId: Int, isUnread: Boolean, sortAscending: Boolean = false
): List
```

The call site was:

```kotlin
articleDao.queryMetadataAll(accountId, !isUnread)
```

Because `!isUnread` is a `Boolean`, Kotlin resolves this to the first overload, treating `!isUnread` as `sortAscending` instead of `isUnread`. As a result, the unread filter is never applied and articles are always queried without considering their read status. Because of this, Read You marks all the articles as read, including the articles already read. This triggered another bug in Miniflux and made me find this bug.

## Fix

Use a named argument to ensure the correct overload is dispatched:

```kotlin
articleDao.queryMetadataAll(accountId, isUnread = !isUnread)
```

## Context

This bug was discovered while investigating a related issue in Miniflux (miniflux/v2#4277), where marking an already-read entry as read would incorrectly toggle it back to unread. Even though fixing Miniflux would mask the symptom on the server side, the incorrect dispatch here is an independent bug — Read You was never calling the intended overload regardless of server behavior.