### PR TITLE
test: cover OPML import behavior

### DIFF
--- a/app/src/test/java/me/ash/reader/infrastructure/rss/OPMLDataSourceTest.kt
+++ b/app/src/test/java/me/ash/reader/infrastructure/rss/OPMLDataSourceTest.kt
@@ -72,4 +72,30 @@ class OPMLDataSourceTest {
         Assert.assertEquals("ash7.io", result[1].feeds[0].name)
         Assert.assertEquals("https://ash7.io/index.xml", result[1].feeds[0].url)
     }
+
+    @Test
+    fun testTopLevelFeedUsesDefaultGroup() {
+        val opml = fill("""
+            <outline type="rss" text="Loose Feed" xmlUrl="https://loose.example/feed.xml"/>
+        """)
+        val result = parse(opml)
+        Assert.assertEquals(1, result.size)
+        Assert.assertEquals(defaultGroup.id, result[0].feeds[0].groupId)
+        Assert.assertEquals("Loose Feed", result[0].feeds[0].name)
+    }
+
+    @Test
+    fun testReadYouAttributesAndFallbackName() {
+        val opml = fill("""
+            <outline text="Blogs" title="Blogs">
+                <outline type="rss" xmlUrl="https://ash7.io/index.xml"
+                    isNotification="true" isFullContent="true" isBrowser="true"/>
+            </outline>
+        """)
+        val feed = parse(opml)[1].feeds[0]
+        Assert.assertEquals("ash7.io", feed.name)
+        Assert.assertTrue(feed.isNotification)
+        Assert.assertTrue(feed.isFullContent)
+        Assert.assertTrue(feed.isBrowser)
+    }
 }


### PR DESCRIPTION
## Summary

- cover top-level OPML feeds being assigned to the default group
- cover Read You OPML flags for notification, full-content, and browser behavior
- cover feed-name fallback from the feed URL domain

## Test plan

- ANDROID_HOME=/Users/sgallese/Library/Android/sdk ./gradlew testGithubReleaseUnitTest --tests me.ash.reader.infrastructure.rss.OPMLDataSourceTest --max-workers=2
- ANDROID_HOME=/Users/sgallese/Library/Android/sdk ./gradlew testGithubReleaseUnitTest --max-workers=2
- ANDROID_HOME=/Users/sgallese/Library/Android/sdk ./gradlew assembleGithubRelease --max-workers=2
- ANDROID_HOME=/Users/sgallese/Library/Android/sdk gradle assembleGithubRelease --max-workers=2