### PR TITLE
docs: update README-zh-TW to sync with English version

### DIFF
--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img width="200" height="200" style="display: block; border: 1px solid #f5f5f5; border-radius: 9999px;" src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/zh-TW/images/icon.png">
+    <img width="200" height="200" style="display: block; border: 1px solid #f5f5f5; border-radius: 9999px;" src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/en-US/images/icon.png">
 </div>
 
 <br>
@@ -23,95 +23,140 @@
 
 <div align="center">
     <h1>Read You</h1>
-    <p>這是一個在 Android 上的  <a href="https://reederapp.com/">Reeder</a> 仿製品，為了讓 Android 擁有一個與 Reeder 相似的 RSS 閱讀器。</p>
-    <p><a target="_blank" href="https://github.com/ReadYouApp/ReadYou/blob/main/README.md">English by DeepL</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+    <p>一款以 <a target="_blank" href="https://m3.material.io/">Material You</a> 風格呈現的 Android RSS 閱讀器。</p>
+    <p><a target="_blank" href="https://github.com/ReadYouApp/ReadYou/blob/main/README.md">English</a>&nbsp;&nbsp;|&nbsp;&nbsp;
     <a target="_blank" href="https://github.com/ReadYouApp/ReadYou/blob/main/README-de.md">Deutsch</a>&nbsp;&nbsp;|&nbsp;&nbsp;
     <a target="_blank" href="https://github.com/ReadYouApp/ReadYou/blob/main/README-zh-CN.md">简体中文</a>&nbsp;&nbsp;|&nbsp;&nbsp;
-    <a target="_blank" href="https://github.com/ReadYouApp/ReadYou/blob/main/README-fa.md">فارسی</a></p>
-    繁體中文</p>
+    <a target="_blank" href="https://github.com/ReadYouApp/ReadYou/blob/main/README-zh-TW.md">繁體中文</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+    <a target="_blank" href="https://github.com/ReadYouApp/ReadYou/blob/main/README-fa.md">فارسی (Outdated)</a></p>
     <br/>
     <br/>
-    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/zh-TW/images/phoneScreenshots/startup.png" width="19.2%"alt="startup" />
-    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/zh-TW/images/phoneScreenshots/feeds.png" width="19.2%" alt="feeds" />
-    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/zh-TW/images/phoneScreenshots/flow.png" width="19.2%" alt="flow" />
-    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/zh-TW/images/phoneScreenshots/read.png" width="19.2%" alt="read" />
-    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/zh-TW/images/phoneScreenshots/settings.png" width="19.2%" alt="settings" />
+    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/en-US/images/phoneScreenshots/startup.png" width="19.2%" alt="startup" />
+    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/en-US/images/phoneScreenshots/feeds.png" width="19.2%" alt="feeds" />
+    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/en-US/images/phoneScreenshots/flow.png" width="19.2%" alt="flow" />
+    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/en-US/images/phoneScreenshots/read.png" width="19.2%" alt="read" />
+    <img src="https://raw.githubusercontent.com/ReadYouApp/ReadYou/main/fastlane/metadata/android/en-US/images/phoneScreenshots/settings.png" width="19.2%" alt="settings" />
     <br/>
     <br/>
 </div>
 
-## 特性
+## 功能特性
 
-**Read You** 結合了 Reeder 的交互邏輯與 [Material Design 3 (You)](https://m3.material.io/) 的設計風格。
+**Read You** 是一款以 [Material You](https://m3.material.io/) 風格呈現的 Android RSS 閱讀器。
 
-以下是目前取得的進展和近期將要努力的目標：
+以下是目前已完成的進展，以及近期將努力實現的目標：
 
--   [x] 本地
+- [x] 訂閱 RSS 連結
+- [x] 匯入或匯出 OPML 文件
+- [x] 新文章通知
+- [x] 文章閱讀體驗優化
+- [x] 原始文章全文解析
+- [x] 多帳戶支援
+- [x] 朗讀文章
+- [ ] Android 桌面小工具
+- [ ] ...
 
-    -   [x] 訂閱 RSS 連結
-    -   [x] 匯入 OPML 文件
-    -   [x] 文章同步
-    -   [x] 文章更新通知
-    -   [x] 全文分析
-    -   [x] 過濾未讀、星標
-    -   [x] 訂閱源分組
-    -   [x] 本地化
-    -   [x] 匯出 OPML 文件
-    -   [x] 文章搜尋
-    -   [ ] 偏好設定
-    -   [ ] 發布 APK
-    -   [ ] 小工具
-    -   [ ] ...
+## 第三方服務整合
 
--   [ ] Fever API 支持
--   [ ] Google Reader API 支持
--   [ ] Inoreader API 支持
--   [ ] ...
+**Read You** 整合了多個第三方服務 API，讓您可以使用現有的雲端帳戶作為資料來源。
 
-> 以上特性僅是初步實現，可能存在某些未知 BUG，仍需進行測試和最佳化。
+- [x] Fever
+- [x] Google Reader
+- [x] FreshRSS
+- [ ] Miniflux
+- [ ] Tiny Tiny RSS
+- [ ] Inoreader
+- [ ] Feedly
+- [ ] Feedbin
+- [ ] ...
 
-## 下载
+## 下載
 
+[<img src="https://s1.ax1x.com/2023/01/12/pSu1a36.png" alt="Get it on GitHub" height="80">](https://github.com/ReadYouApp/ReadYou/releases)
+[<img src="https://s1.ax1x.com/2023/01/12/pSnTZ0f.png"
+     alt="Get it on Telegram Channel"
+     height="80">](https://t.me/ReadYouApp)
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
      alt="Get it on F-Droid"
      height="80">](https://f-droid.org/packages/me.ash.reader/)
 
-或者从 [GitHub release](https://github.com/ReadYouApp/ReadYou/releases) 获取 APK 文件。
+F-Droid 版本無法升級至其他發布渠道的版本，其編譯、簽署及發布均由 [F-Droid](https://f-droid.org/docs/FAQ_-_General/) 統一管理。
 
-## 翻译
+## 每夜構建版本（Nightly）
 
-<a target="_blank" href="https://hosted.weblate.org/engage/readyou/">
-<img src="https://hosted.weblate.org/widgets/readyou/-/287x66-white.png" alt="" />
-</a>
+我們提供 Nightly 版本供測試使用。這些版本包含最新的功能與改進，但穩定性可能不及正式版本。請注意，Nightly 構建可能存在 Bug，不建議作為日常使用版本。
+
+您可以透過以下連結下載 Nightly 版本：
+
+<a target="_blank" href="https://github.com/ReadYouApp/ReadYou/actions/workflows/build_commit.yaml">查看 Nightly 構建</a>
+
+在 GitHub Actions 頁面選擇最新的工作流程，並從工作流程摘要頁面下載 Artifacts（可能需要登入 GitHub）。
+
+**在試用 Nightly 版本前，請務必備份您的資料以防萬一。**
+
+## 贊助
+
+**Read You** 是一款免費的開源軟體，受益於開源社群的支持，每位使用者均可免費享用其完整功能。如果您喜歡我目前的工作，歡迎請我喝杯咖啡。☕️
+
+[<img src="https://s1.ax1x.com/2023/01/12/pSnHqpQ.png" alt="donate" height="80">](https://ash7.io/sponsor)
+
+感謝所有的愛與支持。❤️
+
+## 本地化翻譯
+
+感謝每一位 **Read You** 的翻譯貢獻者。如果您也想參與貢獻，請透過 [Weblate](https://hosted.weblate.org/engage/readyou/) 提交翻譯。
+
+[<img src="https://hosted.weblate.org/widgets/readyou/-/horizontal-auto.svg" alt="" />](https://hosted.weblate.org/engage/readyou/)
 
 ## 構建
 
-> 如果你想要預覽 Read You 應用，可以在 [Telegram 頻道](https://t.me/ReadYouApp) 中獲取 **預覽版本** 的 APK 文件。
+> 歡迎提交 [Pull Request](https://github.com/ReadYouApp/ReadYou/pulls)。[GitHub Actions](https://github.com/ReadYouApp/ReadYou/actions) 會自動為每次提交打包所有版本的 APK 文件。
 
-**Read You** 基於 Android 原生的 [Jetpack Compose](https://developer.android.com/jetpack/compose) 架構實現。
+**Read You** 基於 Android 原生的 [Jetpack Compose](https://developer.android.com/jetpack/compose) 工具包構建。
 
-1. 首先需要獲取 **Read You** 的原始碼：
+1. 首先需要取得 **Read You** 的原始碼：
 
-    ```shell
-    git clone https://github.com/ReadYouApp/ReadYou.git
-    ```
+   ```shell
+   git clone https://github.com/ReadYouApp/ReadYou.git
+   ```
 
-2. 然後通過 [Android Studio (最新版本)](https://developer.android.com/studio) 打開。
+2. 然後透過 [Android Studio（最新版本）](https://developer.android.com/studio) 開啟。
 
 3. 點擊 `▶ 運行（Run）` 按鈕後將會自動構建並運行。
 
     > 如遇卡頓現象，請選擇 Release 版本構建。
 
-## 感謝開源
+## 致謝
 
--   [MusicYou](https://github.com/Kyant0/MusicYou)
--   [ParseRSS](https://github.com/muhrifqii/ParseRSS): [MIT](https://github.com/muhrifqii/ParseRSS/blob/master/LICENSE)
--   [Readability4J](https://github.com/dankito/Readability4J): [Apache License 2.0](https://github.com/dankito/Readability4J/blob/master/LICENSE)
--   [opml-parser](https://github.com/mdewilde/opml-parser): [Apache License 2.0](https://github.com/mdewilde/opml-parser/blob/master/LICENSE)
--   [compose-html](https://github.com/ireward/compose-html): [Apache License 2.0](https://github.com/ireward/compose-html/blob/main/LICENSE.txt)
--   [Rome](https://github.com/rometools/rome): [Apache License 2.0](https://github.com/rometools/rome/blob/master/LICENSE)
--   [Feeder](https://gitlab.com/spacecowboy/Feeder): [GPL v3.0](https://gitlab.com/spacecowboy/Feeder/-/blob/master/LICENSE)
+### 開源專案
+
+- [MusicYou](https://github.com/Kyant0/MusicYou)
+- [ParseRSS](https://github.com/muhrifqii/ParseRSS)
+- [Readability4J](https://github.com/dankito/Readability4J)
+- [opml-parser](https://github.com/mdewilde/opml-parser)
+- [compose-html](https://github.com/ireward/compose-html)
+- [Rome](https://github.com/rometools/rome)
+- [Feeder](https://gitlab.com/spacecowboy/Feeder)
+- [Seal](https://github.com/JunkFood02/Seal)
+- [news-flash](https://gitlab.com/news-flash)
+- [besticon](https://github.com/mat/besticon)
+- [Jiffy Reader](https://github.com/ansh/jiffyreader.com)
+- ...
+
+### 特別感謝
+
+[<img src="https://avatars.githubusercontent.com/u/76829190?v=4" width="180" height="180" style="display: block; border: 1px solid #f5f5f5; border-radius: 9999px;"/>](https://github.com/Kyant0)
+
+感謝 **@Kyant0** 為 **Read You** 提供的設計靈感與 Monet 引擎實作。
+
+[<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.png" width="200" alt="Copyright © 2000-2023 JetBrains s.r.o. JetBrains and the JetBrains logo are registered trademarks of JetBrains s.r.o."/>](https://www.jetbrains.com/)
+
+感謝 **JetBrains** 為 **Read You** 提供免費的開源 IDE 授權。
+
+[<img src="https://hosted.weblate.org/widgets/readyou/-/287x66-white.png" width="200"/>](https://hosted.weblate.org/engage/readyou/)
+
+感謝 **Weblate** 為 **Read You** 提供免費的開源專案翻譯託管服務。
 
 ## 許可證
 
-[GNU GPL v3.0](https://github.com/ReadYouApp/ReadYou/blob/main/LICENSE)
+GNU GPL v3.0 © [Read You](https://github.com/ReadYouApp/ReadYou/blob/main/LICENSE)


### PR DESCRIPTION
- Fix outdated app description (Reeder clone -> Material You RSS reader)
- Rewrite feature list to match current English README
- Update integration list: mark Fever/GReader/FreshRSS as completed, add missing services
- Add missing sections: Nightly builds, Sponsorship, Localization
- Add missing download buttons (GitHub, Telegram)
- Add missing credits: Seal, news-flash, besticon, Jiffy Reader
- Add Special Thanks section (Kyant0, JetBrains, Weblate)
- Fix language switcher links