### PR TITLE
fix: use URL keyboard for subscribe field

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt
@@ -21,6 +21,7 @@ fun ClipboardTextField(
     isPassword: Boolean = false,
     errorText: String = "",
     imeAction: ImeAction = ImeAction.Done,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     onConfirm: (String) -> Unit = {},
 ) {
     Column(modifier = Modifier) {
@@ -37,7 +38,7 @@ fun ClipboardTextField(
                 if (imeAction != ImeAction.Default || imeAction != ImeAction.None) {
                     KeyboardActionHandler { onConfirm(state.text.toString()) }
                 } else null,
-            keyboardOptions = KeyboardOptions(imeAction = imeAction),
+            keyboardOptions = keyboardOptions.copy(imeAction = imeAction),
         )
         Spacer(modifier = Modifier.height(10.dp))
     }

--- a/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt
@@ -38,8 +38,11 @@ fun ClipboardTextField(
                 if (imeAction != ImeAction.Default || imeAction != ImeAction.None) {
                     KeyboardActionHandler { onConfirm(state.text.toString()) }
                 } else null,
-            keyboardOptions = keyboardOptions.copy(imeAction = imeAction),
+            keyboardOptions = keyboardOptions.withImeAction(imeAction),
         )
         Spacer(modifier = Modifier.height(10.dp))
     }
 }
+
+internal fun KeyboardOptions.withImeAction(imeAction: ImeAction): KeyboardOptions =
+    copy(imeAction = imeAction)

--- a/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt
@@ -1,5 +1,6 @@
 package me.ash.reader.ui.component.base
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -44,5 +45,6 @@ fun ClipboardTextField(
     }
 }
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal fun KeyboardOptions.withImeAction(imeAction: ImeAction): KeyboardOptions =
     copy(imeAction = imeAction)

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt
@@ -2,6 +2,7 @@ package me.ash.reader.ui.page.home.feeds.subscribe
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.fadeIn
@@ -254,5 +255,6 @@ fun SubscribeDialog(
     }
 }
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal fun subscribeUrlKeyboardOptions(): KeyboardOptions =
     KeyboardOptions(keyboardType = KeyboardType.Uri)

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt
@@ -129,7 +129,7 @@ fun SubscribeDialog(
                                 placeholder = stringResource(R.string.feed_or_site_url),
                                 errorText = errorText,
                                 imeAction = ImeAction.Search,
-                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                                keyboardOptions = subscribeUrlKeyboardOptions(),
                                 onConfirm = {
                                     subscribeViewModel.searchFeed()
                                 },
@@ -253,3 +253,6 @@ fun SubscribeDialog(
         )
     }
 }
+
+internal fun subscribeUrlKeyboardOptions(): KeyboardOptions =
+    KeyboardOptions(keyboardType = KeyboardType.Uri)

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CreateNewFolder
 import androidx.compose.material.icons.rounded.RssFeed
@@ -24,6 +25,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
@@ -127,6 +129,7 @@ fun SubscribeDialog(
                                 placeholder = stringResource(R.string.feed_or_site_url),
                                 errorText = errorText,
                                 imeAction = ImeAction.Search,
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
                                 onConfirm = {
                                     subscribeViewModel.searchFeed()
                                 },

--- a/app/src/test/java/me/ash/reader/ui/component/base/ClipboardTextFieldTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/component/base/ClipboardTextFieldTest.kt
@@ -1,0 +1,18 @@
+package me.ash.reader.ui.component.base
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClipboardTextFieldTest {
+    @Test
+    fun withImeAction_preservesKeyboardType() {
+        val options =
+            KeyboardOptions(keyboardType = KeyboardType.Uri).withImeAction(ImeAction.Search)
+
+        assertEquals(KeyboardType.Uri, options.keyboardType)
+        assertEquals(ImeAction.Search, options.imeAction)
+    }
+}

--- a/app/src/test/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialogTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialogTest.kt
@@ -1,0 +1,12 @@
+package me.ash.reader.ui.page.home.feeds.subscribe
+
+import androidx.compose.ui.text.input.KeyboardType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubscribeDialogTest {
+    @Test
+    fun subscribeUrlKeyboardOptions_usesUriKeyboard() {
+        assertEquals(KeyboardType.Uri, subscribeUrlKeyboardOptions().keyboardType)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/ReadYouApp/ReadYou/issues/1257.

- Use URL keyboard options for the Subscribe dialog URL field.
- Preserve the existing `Search` IME action.
- Keep `ClipboardTextField` defaults unchanged for other callers.

## Test plan

- Added unit tests for the URL keyboard options and IME-action merge.
- Tested `https://alignedtrack432.neocities.org/feed.xml`; it keeps the URL keyboard active and resolves to the `Sidetracked` subscribe candidate.
- Tested a duplicate feed URL; it keeps the URL keyboard active and shows the existing `Already subscribed` error.

## Evidence

<img src="https://github.com/user-attachments/assets/bb4d1541-1462-4484-86f6-b09a8579a3c6" alt="Subscribe URL field showing URL keyboard without suggestions" width="280" />

- [Recording: issue URL resolves to the Sidetracked feed](https://github.com/user-attachments/assets/9adb6b8b-32d7-4b50-aa11-ea489a888924)
- [Recording: valid feed search reaches subscribe options](https://github.com/user-attachments/assets/63cadc9b-459b-4c8f-ab3e-03d47074baad)
- [Recording: duplicate feed shows Already subscribed](https://github.com/user-attachments/assets/4d3c9935-d944-4d54-b6bf-f4ef2deffb28)
