### PR TITLE
fix(greader): keep the trailing slash when editing an account server URL

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/connection/FreshRSSConnection.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/connection/FreshRSSConnection.kt
@@ -84,7 +84,7 @@ fun LazyItemScope.FreshRSSConnection(
         onDismissRequest = { serverUrlDialogVisible = false },
         onConfirm = {
             if (securityKey.serverUrl?.isNotBlank() == true) {
-                securityKey.serverUrl = serverUrlValue
+                securityKey.serverUrl = serverUrlValue?.let { if (it.endsWith("/")) it else "$it/" }
                 save(account, viewModel, securityKey)
                 serverUrlDialogVisible = false
             }

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/connection/GoogleReaderConnection.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/connection/GoogleReaderConnection.kt
@@ -84,7 +84,7 @@ fun LazyItemScope.GoogleReaderConnection(
         onDismissRequest = { serverUrlDialogVisible = false },
         onConfirm = {
             if (securityKey.serverUrl?.isNotBlank() == true) {
-                securityKey.serverUrl = serverUrlValue
+                securityKey.serverUrl = serverUrlValue?.let { if (it.endsWith("/")) it else "$it/" }
                 save(account, viewModel, securityKey)
                 serverUrlDialogVisible = false
             }


### PR DESCRIPTION
### What

`AddGoogleReaderAccountDialog` appends a trailing slash to the server URL, but the *edit* dialog in `GoogleReaderConnection` stores the value as typed. Since `GoogleReaderAPI` concatenates without a separator — `.url("${serverUrl}accounts/ClientLogin")` — editing an existing account's URL to `https://example.org/api/greader.php` produces a request to `https://example.org/api/greader.phpaccounts/ClientLogin`, and sync fails with a `GoogleReaderAPIException` carrying the server's raw 404 page.

The same one-liner is missing in `FreshRSSConnection`, whose add dialog also appends the slash.

### Repro

1. Add a FreshRSS account (works — the add dialog fixes up the URL).
2. Settings → Accounts → the account → Server URL, retype it without the trailing slash.
3. Sync → 404.

This is #837, closed at the time as "seems fixed" but still reproducible on `main`.

### Fix

Normalize on save in both connection screens, the way the add dialogs already do — same shape as #357, which fixed the equivalent Fever bug in both the add and the edit path.
