### PR TITLE
fix(rss): bypass WAF bot blocking with browser User-Agent and fix search feed hang

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -63,7 +63,7 @@ abstract class AbstractRssRepository(
         val feed =
             Feed(
                 id = accountId.spacerDollar(UUID.randomUUID().toString()),
-                name = searchedFeed.title.decodeHTML()!!,
+                name = searchedFeed.title?.decodeHTML() ?: feedLink,
                 url = feedLink,
                 groupId = groupId,
                 accountId = accountId,

--- a/app/src/main/java/me/ash/reader/infrastructure/di/OkHttpClientModule.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/di/OkHttpClientModule.kt
@@ -62,6 +62,7 @@ object OkHttpClientModule {
         context = context,
         cacheDirectory = context.cacheDir.resolve("http")
     ).newBuilder()
+        .addInterceptor(UserAgentInterceptor)
         .addNetworkInterceptor(UserAgentInterceptor)
         .build()
 }
@@ -82,6 +83,7 @@ fun cachingHttpClient(
     }
 
     builder
+        .addInterceptor(UserAgentInterceptor)
         .connectTimeout(connectTimeoutSecs, TimeUnit.SECONDS)
         .readTimeout(readTimeoutSecs, TimeUnit.SECONDS)
         .followRedirects(true)
@@ -165,13 +167,21 @@ fun OkHttpClient.Builder.setupSsl(
 object UserAgentInterceptor : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val existingUa = request.header("User-Agent")
+        val userAgent = if (existingUa.isNullOrBlank() || existingUa.startsWith("okhttp", ignoreCase = true)) {
+            USER_AGENT_STRING
+        } else {
+            existingUa
+        }
         return chain.proceed(
-            chain.request()
+            request
                 .newBuilder()
-                .header("User-Agent", USER_AGENT_STRING)
+                .header("User-Agent", userAgent)
                 .build()
         )
     }
 }
 
-const val USER_AGENT_STRING = BuildConfig.USER_AGENT_STRING
+const val USER_AGENT_STRING =
+    "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Mobile Safari/537.36"

--- a/app/src/main/java/me/ash/reader/infrastructure/rss/BestIconFinder.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/BestIconFinder.kt
@@ -10,15 +10,15 @@ class BestIconFinder(private val client: OkHttpClient) {
 
     private val defaultFormats = listOf("apple-touch-icon", "svg", "png", "ico", "gif", "jpg")
 
-    suspend fun findBestIcon(siteUrl: String): String? {
+    suspend fun findBestIcon(siteUrl: String): String? = runCatching {
         val url = normalizeUrl(siteUrl)
         val icons = fetchIcons(url)
-        return selectBestIcon(icons)
-    }
+        selectBestIcon(icons)
+    }.getOrNull()
 
     private fun normalizeUrl(url: String): String {
         return if (!url.startsWith("http://") && !url.startsWith("https://")) {
-            "http://$url"
+            "https://$url"
         } else {
             url
         }
@@ -34,7 +34,7 @@ class BestIconFinder(private val client: OkHttpClient) {
             defaultIconUrls(url)
         }
 
-        return links.mapNotNull { fetchIconDetails(it) }
+        return links.take(4).mapNotNull { fetchIconDetails(it) }
     }
 
     private suspend fun fetchHtml(url: String): String {

--- a/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
@@ -55,22 +55,28 @@ constructor(
     suspend fun searchFeed(feedLink: String): SearchFeedResult {
         return withContext(ioDispatcher) {
             val directResponse = response(okHttpClient, feedLink)
-            if (!directResponse.commonIsSuccessful) throw IOException(directResponse.message)
             val directBody = directResponse.body.bytes()
             val directHttpContentType = toHttpContentType(directResponse.header("Content-Type"))
 
-            val parsedDirectFeed = runCatching { parseFeed(directBody, directHttpContentType) }.getOrNull()
+            val parsedDirectFeed = if (directResponse.commonIsSuccessful) {
+                runCatching { parseFeed(directBody, directHttpContentType) }.getOrNull()
+            } else null
 
             val resolvedFeedLink =
                 if (parsedDirectFeed != null) feedLink
                 else discoverFeedLink(feedLink, directBody)
-                    ?: throw IOException("Unable to detect RSS feed URL")
-
+                    ?: throw IOException(
+                        if (!directResponse.commonIsSuccessful) {
+                            "HTTP ${directResponse.code}: ${directResponse.message}"
+                        } else {
+                            "Unable to detect RSS feed URL"
+                        }
+                    )
 
             val feed = parsedDirectFeed ?: run {
                 val discoveredResponse = response(okHttpClient, resolvedFeedLink)
                 if (!discoveredResponse.commonIsSuccessful) {
-                    throw IOException(discoveredResponse.message)
+                    throw IOException("HTTP ${discoveredResponse.code}: ${discoveredResponse.message}")
                 }
                 parseFeed(
                     discoveredResponse.body.bytes(),
@@ -167,10 +173,14 @@ constructor(
         feed: Feed,
         latestLink: String?,
         preDate: Date = Date(),
-    ): List<Article> =
-        try {
+    ): List<Article> {
+        return try {
             val accountId = context.currentAccountId
             val response = response(okHttpClient, feed.url)
+            if (!response.commonIsSuccessful) {
+                Log.w("RLog", "queryRssXml[${feed.name}]: HTTP ${response.code} ${response.message}")
+                return emptyList()
+            }
             val contentType = response.header("Content-Type")
 
             val httpContentType =
@@ -194,6 +204,7 @@ constructor(
             Log.e("RLog", "queryRssXml[${feed.name}]: ${e.message}")
             listOf()
         }
+    }
 
     fun buildArticleFromSyndEntry(
         feed: Feed,
@@ -282,14 +293,14 @@ constructor(
         return imgRegex.find(text)?.groupValues?.get(2)?.takeIf { !it.startsWith("data:") }
     }
 
-    suspend fun queryRssIconLink(feedLink: String?): String? {
-        if (feedLink.isNullOrEmpty()) return null
+    suspend fun queryRssIconLink(feedLink: String?): String? = runCatching {
+        if (feedLink.isNullOrEmpty()) return@runCatching null
         val iconFinder = BestIconFinder(okHttpClient)
         val domain = feedLink.extractDomain()
-        return iconFinder.findBestIcon(domain ?: feedLink).also {
+        iconFinder.findBestIcon(domain ?: feedLink).also {
             Log.i("RLog", "queryRssIconByLink: get $it from $domain")
         }
-    }
+    }.getOrNull()
 
     suspend fun saveRssIcon(feedDao: FeedDao, feed: Feed, iconLink: String) {
         feedDao.update(feed.copy(icon = iconLink))

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeViewModel.kt
@@ -144,7 +144,7 @@ constructor(
                 return@launch
             }
             val groups = groupsFlow.value
-            val firstGroupId = groups.firstOrNull()?.id ?: return@launch
+            val firstGroupId = groups.firstOrNull()?.id ?: ""
 
             val job =
                 viewModelScope.launch {

--- a/app/src/test/java/me/ash/reader/infrastructure/di/OkHttpClientModuleTest.kt
+++ b/app/src/test/java/me/ash/reader/infrastructure/di/OkHttpClientModuleTest.kt
@@ -1,0 +1,90 @@
+package me.ash.reader.infrastructure.di
+
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OkHttpClientModuleTest {
+
+    @Test
+    fun testUserAgentStringIsBrowserCompatible() {
+        assertTrue(USER_AGENT_STRING.startsWith("Mozilla/5.0"))
+        assertTrue(USER_AGENT_STRING.contains("Mobile"))
+        assertTrue(!USER_AGENT_STRING.contains("ReadYou"))
+    }
+
+    @Test
+    fun testUserAgentInterceptorAppliesDefaultUserAgent() {
+        var interceptedRequest: Request? = null
+
+        val fakeChain = object : Interceptor.Chain {
+            override fun request(): Request = Request.Builder().url("https://example.com/rss.xml").build()
+
+            override fun proceed(request: Request): Response {
+                interceptedRequest = request
+                return Response.Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body("".toResponseBody())
+                    .build()
+            }
+
+            override fun call(): okhttp3.Call = throw NotImplementedError()
+            override fun connection(): okhttp3.Connection? = null
+            override fun connectTimeoutMillis(): Int = 0
+            override fun readTimeoutMillis(): Int = 0
+            override fun writeTimeoutMillis(): Int = 0
+            override fun withConnectTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit): Interceptor.Chain = this
+            override fun withReadTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit): Interceptor.Chain = this
+            override fun withWriteTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit): Interceptor.Chain = this
+        }
+
+        UserAgentInterceptor.intercept(fakeChain)
+
+        assertEquals(USER_AGENT_STRING, interceptedRequest?.header("User-Agent"))
+    }
+
+    @Test
+    fun testUserAgentInterceptorPreservesCustomUserAgent() {
+        var interceptedRequest: Request? = null
+        val customUa = "CustomApp/1.0"
+
+        val fakeChain = object : Interceptor.Chain {
+            override fun request(): Request = Request.Builder()
+                .url("https://example.com/rss.xml")
+                .header("User-Agent", customUa)
+                .build()
+
+            override fun proceed(request: Request): Response {
+                interceptedRequest = request
+                return Response.Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body("".toResponseBody())
+                    .build()
+            }
+
+            override fun call(): okhttp3.Call = throw NotImplementedError()
+            override fun connection(): okhttp3.Connection? = null
+            override fun connectTimeoutMillis(): Int = 0
+            override fun readTimeoutMillis(): Int = 0
+            override fun writeTimeoutMillis(): Int = 0
+            override fun withConnectTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit): Interceptor.Chain = this
+            override fun withReadTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit): Interceptor.Chain = this
+            override fun withWriteTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit): Interceptor.Chain = this
+        }
+
+        UserAgentInterceptor.intercept(fakeChain)
+
+        assertEquals(customUa, interceptedRequest?.header("User-Agent"))
+    }
+}

--- a/app/src/test/java/me/ash/reader/infrastructure/rss/RssHelperTest.kt
+++ b/app/src/test/java/me/ash/reader/infrastructure/rss/RssHelperTest.kt
@@ -87,4 +87,62 @@ class RssHelperTest {
         """
         Assert.assertEquals(imageUrlString, rssHelper.findThumbnail(case))
     }
+
+    @Test
+    fun testParseRss20Feed() {
+        val sampleFeedXml = """
+            <?xml version="1.0"?>
+            <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+             <channel>
+                <title>Phoronix</title>
+                <link>https://www.phoronix.com/</link>
+                <description>Linux Hardware Reviews, Performance Benchmarks</description>
+                <language>en-us</language>
+              <item>
+               <title>Sample Linux Article</title>
+               <link>https://www.phoronix.com/news/sample-linux-article</link>
+               <guid>https://www.phoronix.com/news/sample-linux-article</guid>
+               <description>Sample article description.</description>
+               <pubDate>Sun, 23 Aug 2026 07:41:04 -0400</pubDate>
+               <dc:creator>Michael Larabel</dc:creator>
+              </item>
+             </channel>
+            </rss>
+        """.trimIndent()
+
+        val inputStream = java.io.ByteArrayInputStream(sampleFeedXml.toByteArray(Charsets.UTF_8))
+        val syndFeed = com.rometools.rome.io.SyndFeedInput().build(com.rometools.rome.io.XmlReader(inputStream, "text/xml; charset=UTF-8"))
+        Assert.assertEquals("Phoronix", syndFeed.title)
+        Assert.assertEquals(1, syndFeed.entries.size)
+        Assert.assertEquals("Sample Linux Article", syndFeed.entries[0].title)
+        Assert.assertEquals("Michael Larabel", syndFeed.entries[0].author)
+    }
+
+    @Test
+    fun testRealSearchFeedPhoronix() {
+        val client = okhttp3.OkHttpClient.Builder()
+            .addNetworkInterceptor(me.ash.reader.infrastructure.di.UserAgentInterceptor)
+            .build()
+        val helper = RssHelper(mockContext, kotlinx.coroutines.Dispatchers.IO, client)
+        kotlinx.coroutines.runBlocking {
+            val result = helper.searchFeed("https://www.phoronix.com/rss.php")
+            Assert.assertNotNull(result.feed)
+            Assert.assertEquals("Phoronix", result.feed.title)
+            Assert.assertEquals("https://www.phoronix.com/rss.php", result.feedLink)
+        }
+    }
+
+    @Test
+    fun testRealDiscoverFeedPhoronix() {
+        val client = okhttp3.OkHttpClient.Builder()
+            .addNetworkInterceptor(me.ash.reader.infrastructure.di.UserAgentInterceptor)
+            .build()
+        val helper = RssHelper(mockContext, kotlinx.coroutines.Dispatchers.IO, client)
+        kotlinx.coroutines.runBlocking {
+            val result = helper.searchFeed("https://www.phoronix.com")
+            Assert.assertNotNull(result.feed)
+            Assert.assertEquals("Phoronix", result.feed.title)
+            Assert.assertEquals("https://www.phoronix.com/rss.php", result.feedLink)
+        }
+    }
 }


### PR DESCRIPTION
﻿### What & Why

Fixes #1164
Related to #13

When subscribing to feeds protected by Cloudflare WAF / Bot Fight Mode (such as `https://www.phoronix.com/rss.php`), the request was blocked with HTTP 403 Forbidden and a Cloudflare HTML challenge page, throwing:
`Invalid XML: Error on line 1: At line 1, column 766: not well-formed (invalid token)`

Additionally:
1. OkHttp's `BridgeInterceptor` was injecting its default `User-Agent: okhttp/...`, which was not replaced when checking `header("User-Agent") == null`.
2. `BestIconFinder` was downloading up to 15 icon candidate variants sequentially in cleartext `http://`, causing the subscribe search dialog to hang in the "Searching..." state for 30+ seconds.
3. In `AbstractRssRepository.kt`, `searchedFeed.title.decodeHTML()!!` had a potential NPE risk.
4. In `SubscribeViewModel.kt`, `searchFeed` aborted if `groupsFlow` was initially empty.

### Fixes Applied

- **Browser User-Agent (`OkHttpClientModule.kt`)**: Set standard Android browser `User-Agent` (`Mozilla/5.0 ...`) at both application and network interceptor levels, filtering out OkHttp's internal default User-Agent.
- **Fast & Safe Icon Finder (`BestIconFinder.kt`)**: Default to `https://`, limit icon probing to a max of 4 candidates, and wrap all icon fetching in `runCatching` so icon resolution never blocks or fails feed addition.
- **Robust RSS Search & Sync (`RssHelper.kt`)**: Check `response.commonIsSuccessful` before attempting to parse bodies as XML, logging clear HTTP error codes rather than passing HTML error pages into ROME's `XmlReader`.
- **Safe Subscribe & Null-Safety (`AbstractRssRepository.kt` & `SubscribeViewModel.kt`)**: Safe fallback for feed title decoding and empty group handling.
- **Unit Tests**: Added unit and real network integration tests in `OkHttpClientModuleTest` and `RssHelperTest`.

### Tested

- Tested feed search with direct feed URL (`https://www.phoronix.com/rss.php`) and website URL (`https://www.phoronix.com`).
- Ran unit tests: `./gradlew testGithubReleaseUnitTest` -> All passed.
- Built release APK: `./gradlew assembleGithubRelease` -> `BUILD SUCCESSFUL`.
