### PR TITLE
fix(rss): properly detect charset and decode French and non-UTF8 full content

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
@@ -90,7 +90,9 @@ constructor(
 
     private fun toHttpContentType(contentType: String?): String =
         contentType?.let {
-            if (it.contains("charset=", ignoreCase = true)) it else "$it; charset=UTF-8"
+            if (it.contains("charset=", ignoreCase = true)) {
+                it.replace(',', ';')
+            } else "$it; charset=UTF-8"
         } ?: "text/xml; charset=UTF-8"
 
     private fun parseFeed(body: ByteArray, httpContentType: String): SyndFeed =
@@ -112,44 +114,58 @@ constructor(
         return (preferred ?: fallback)?.absUrl("href")?.takeIf { it.isNotBlank() }
     }
 
+    fun detectHtmlCharset(contentTypeHeader: String?, bodyBytes: ByteArray): Charset {
+        // 1. Check HTTP Content-Type header (handles semicolons, commas, and quotes)
+        if (!contentTypeHeader.isNullOrBlank()) {
+            val match = Regex("""(?i)charset\s*=\s*["']?([a-zA-Z0-9_-]+)""").find(contentTypeHeader)
+            if (match != null) {
+                val charsetName = match.groupValues[1].trim('\'', '"', ';', ' ')
+                runCatching { return Charset.forName(charsetName) }
+            }
+        }
+
+        // 2. Check BOM (Byte Order Mark)
+        if (bodyBytes.size >= 3 && bodyBytes[0] == 0xEF.toByte() && bodyBytes[1] == 0xBB.toByte() && bodyBytes[2] == 0xBF.toByte()) {
+            return Charsets.UTF_8
+        }
+        if (bodyBytes.size >= 2 && bodyBytes[0] == 0xFE.toByte() && bodyBytes[1] == 0xFF.toByte()) {
+            return Charsets.UTF_16BE
+        }
+        if (bodyBytes.size >= 2 && bodyBytes[0] == 0xFF.toByte() && bodyBytes[1] == 0xFE.toByte()) {
+            return Charsets.UTF_16LE
+        }
+
+        // 3. Inspect HTML <head> for <meta charset="..."> or <meta http-equiv="content-type" content="...">
+        val previewLength = minOf(bodyBytes.size, 4096)
+        val asciiPreview = String(bodyBytes, 0, previewLength, Charsets.ISO_8859_1)
+
+        val metaCharsetMatch = Regex("""(?i)<meta[^>]+charset\s*=\s*["']?([a-zA-Z0-9_-]+)""").find(asciiPreview)
+        if (metaCharsetMatch != null) {
+            val charsetName = metaCharsetMatch.groupValues[1].trim('\'', '"', ';', ' ')
+            runCatching { return Charset.forName(charsetName) }
+        }
+
+        val metaHttpEquivMatch = Regex("""(?i)<meta[^>]+content\s*=\s*["'][^"']*charset=([a-zA-Z0-9_-]+)""").find(asciiPreview)
+            ?: Regex("""(?i)http-equiv\s*=\s*["']?content-type["']?[^>]+content\s*=\s*["'][^"']*charset=([a-zA-Z0-9_-]+)""").find(asciiPreview)
+        if (metaHttpEquivMatch != null) {
+            val charsetName = metaHttpEquivMatch.groupValues[1].trim('\'', '"', ';', ' ')
+            runCatching { return Charset.forName(charsetName) }
+        }
+
+        // 4. Default to UTF-8
+        return Charsets.UTF_8
+    }
+
     @Throws(Exception::class)
     suspend fun parseFullContent(link: String, title: String): String {
         return withContext(ioDispatcher) {
             val response = response(okHttpClient, link)
             if (response.commonIsSuccessful) {
                 val responseBody = response.body
-                val charset = responseBody.contentType()?.charset()
-                val content =
-                    responseBody.source().use {
-                        if (charset != null) {
-                            return@use it.readString(charset)
-                        }
-
-                        val peekContent = it.peek().readString(Charsets.UTF_8)
-
-                        val charsetFromMeta =
-                            runCatching {
-                                    val element =
-                                        Jsoup.parse(peekContent, link)
-                                            .selectFirst("meta[http-equiv=content-type]")
-                                    return@runCatching if (element == null) Charsets.UTF_8
-                                    else {
-                                        element
-                                            .attr("content")
-                                            .substringAfter("charset=")
-                                            .removeSurrounding("\"")
-                                            .lowercase()
-                                            .let { Charset.forName(it) }
-                                    }
-                                }
-                                .getOrDefault(Charsets.UTF_8)
-
-                        if (charsetFromMeta == Charsets.UTF_8) {
-                            peekContent
-                        } else {
-                            it.readString(charsetFromMeta)
-                        }
-                    }
+                val contentTypeHeader = response.header("Content-Type")
+                val bytes = responseBody.bytes()
+                val charset = detectHtmlCharset(contentTypeHeader, bytes)
+                val content = String(bytes, charset)
 
                 val articleContent = Readability.parseToElement(content, link)
                 articleContent?.let {

--- a/app/src/test/java/me/ash/reader/infrastructure/rss/RssHelperTest.kt
+++ b/app/src/test/java/me/ash/reader/infrastructure/rss/RssHelperTest.kt
@@ -87,4 +87,60 @@ class RssHelperTest {
         """
         Assert.assertEquals(imageUrlString, rssHelper.findThumbnail(case))
     }
+
+    @Test
+    fun testDetectHtmlCharsetFromHeaderWithComma() {
+        val bytes = "<html><body>Test</body></html>".toByteArray(Charsets.ISO_8859_1)
+        val charset = rssHelper.detectHtmlCharset("text/html, charset=iso-8859-1", bytes)
+        Assert.assertEquals(Charsets.ISO_8859_1, charset)
+    }
+
+    @Test
+    fun testDetectHtmlCharsetFromMetaCharset() {
+        val html = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="iso-8859-1">
+                <title>Test</title>
+            </head>
+            <body>Perplexity a lancé son abonnement</body>
+            </html>
+        """.trimIndent()
+        val bytes = html.toByteArray(Charsets.ISO_8859_1)
+        val charset = rssHelper.detectHtmlCharset("text/html", bytes)
+        Assert.assertEquals(Charsets.ISO_8859_1, charset)
+
+        val decoded = String(bytes, charset)
+        Assert.assertTrue(decoded.contains("Perplexity a lancé son abonnement"))
+        Assert.assertFalse(decoded.contains("\uFFFD"))
+    }
+
+    @Test
+    fun testDetectHtmlCharsetFromMetaHttpEquiv() {
+        val html = """
+            <html>
+            <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+            </head>
+            <body>Déjà vu été français</body>
+            </html>
+        """.trimIndent()
+        val win1252 = java.nio.charset.Charset.forName("windows-1252")
+        val bytes = html.toByteArray(win1252)
+        val charset = rssHelper.detectHtmlCharset(null, bytes)
+        Assert.assertEquals(win1252, charset)
+
+        val decoded = String(bytes, charset)
+        Assert.assertTrue(decoded.contains("Déjà vu été français"))
+    }
+
+    @Test
+    fun testFrenchCharactersDecodingAccuracy() {
+        val originalFrenchText = "Club des développeurs : Actualités, cours, tutoriels & événements d'ingénierie"
+        val bytes = originalFrenchText.toByteArray(Charsets.ISO_8859_1)
+        val charset = rssHelper.detectHtmlCharset("text/html, charset=iso-8859-1", bytes)
+        val decoded = String(bytes, charset)
+        Assert.assertEquals(originalFrenchText, decoded)
+    }
 }


### PR DESCRIPTION
﻿### What & Why

Fixes #1094

When fetching and parsing full article content (e.g. from `developpez.com` or other sites declaring ISO-8859-1 / Windows-1252):
- French characters with accents (`é`, `è`, `à`, `ç`, `ê`, `î`, `ô`, `ù`, etc.) were displayed as corrupted replacement symbols (`` or `?`).
- Example: `"Perplexity a lanc son nouvel abonnement Max, factur 200 dollars..."`

### Root Cause
1. **HTTP `Content-Type` Header with Comma**: Some legacy/PHP servers return `Content-Type: text/html, charset=iso-8859-1` with a comma rather than a semicolon. OkHttp's `MediaType.parse()` fails on this format and returns `null` for `responseBody.contentType()?.charset()`.
2. **Missing HTML5 `<meta charset="...">` Detection**: Only `meta[http-equiv=content-type]` was inspected, completely ignoring HTML5 `<meta charset="iso-8859-1">`.
3. **Lossy Stream Peeking**: `it.peek().readString(Charsets.UTF_8)` converted raw ISO-8859-1 bytes (such as `0xE9` for `é`) directly into `\uFFFD`, causing irreversible character loss if meta charset wasn't found in time.

### Fixes Applied
- **Robust Charset Detection (`detectHtmlCharset`) in `RssHelper.kt`**:
  1. Parses charset from HTTP `Content-Type` header (handling both `,` and `;` delimiters as well as quotes).
  2. Inspects HTML `<head>` for `<meta charset="...">` (HTML5) and `<meta http-equiv="content-type" content="...">`.
  3. Checks standard BOM markers (UTF-8, UTF-16).
  4. Defaults safely to `UTF-8`.
- **Direct Byte Decoding in `parseFullContent()`**: Reads the raw response bytes and decodes them directly with the detected charset, preventing lossy intermediate UTF-8 conversions.
- **Header Normalization in `toHttpContentType()`**: Normalizes commas to semicolons when reading feed XML content types.
- **Unit Tests (`RssHelperTest.kt`)**: Added comprehensive tests verifying charset detection from comma-separated headers, HTML5 meta tags, and accurate decoding of French accented text.

### Tested
- Ran unit tests: `./gradlew testGithubReleaseUnitTest` -> `BUILD SUCCESSFUL`.
- Built release APK: `./gradlew assembleGithubRelease` -> `BUILD SUCCESSFUL`.
